### PR TITLE
Add a simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang
+
+WORKDIR /usr/src/franz-go
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/local/bin/kgo-verifier ./...


### PR DESCRIPTION
## Cover Letter

This PR adds a simple Dockerfile that builds `kgo-verifier`. I wrote it for myself in order
to attach `kgo-verifier` pods to a running Kubernetes cluster. Maybe someone else would find it useful.
It would also simplify our internal instructions for creating the set-up I described (currently this code lives
in a gist).