### PR TITLE
Add support for verifying transactions

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -50,6 +50,10 @@ var (
 	loop               = flag.Bool("loop", false, "For readers, run indefinitely until stopped via signal or HTTP call")
 	name               = flag.String("client-name", "kgo", "Name of kafka client")
 	fakeTimestampMs    = flag.Int64("fake-timestamp-ms", -1, "Producer: set artificial batch timestamps on an incrementing basis, starting from this number")
+
+	useTransactions      = flag.Bool("use-transactions", false, "Producer: use a transactional producer")
+	transactionAbortRate = flag.Float64("transaction-abort-rate", 0.0, "The probability that any given transaction should abort")
+	msgsPerTransaction   = flag.Uint("msgs-per-transaction", 1, "The number of messages that should be in a given transaction")
 )
 
 func makeWorkerConfig() worker.WorkerConfig {
@@ -158,6 +162,12 @@ func main() {
 		log.Info("Starting producer...")
 		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs)
 		pw := verifier.NewProducerWorker(pwc)
+
+		if *useTransactions {
+			tconfig := worker.NewTransactionSTMConfig(*transactionAbortRate, *msgsPerTransaction)
+			pw.EnableTransactions(tconfig)
+		}
+
 		workers = append(workers, &pw)
 		waitErr := pw.Wait()
 		util.Chk(err, "Producer error: %v", waitErr)

--- a/pkg/worker/transaction_stm.go
+++ b/pkg/worker/transaction_stm.go
@@ -1,0 +1,114 @@
+package worker
+
+import (
+	"context"
+	"math/rand"
+	_ "net/http/pprof"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type TransactionSTMConfig struct {
+	abortRate          float64
+	msgsPerTransaction uint
+}
+
+func NewTransactionSTMConfig(abortRate float64, msgsPerTransaction uint) TransactionSTMConfig {
+	return TransactionSTMConfig{
+		abortRate:          abortRate,
+		msgsPerTransaction: msgsPerTransaction,
+	}
+}
+
+type TransactionSTM struct {
+	config TransactionSTMConfig
+	client *kgo.Client
+	ctx    context.Context
+
+	activeTransaction  bool
+	abortedTransaction bool
+	currentMgsProduced uint
+}
+
+func NewTransactionSTM(ctx context.Context, client *kgo.Client, config TransactionSTMConfig) *TransactionSTM {
+	log.Debugf("Creating TransactionSTM config = %+v", config)
+
+	return &TransactionSTM{
+		ctx:                ctx,
+		config:             config,
+		client:             client,
+		activeTransaction:  false,
+		abortedTransaction: false,
+		currentMgsProduced: 0,
+	}
+}
+
+func (t *TransactionSTM) TryEndTransaction() error {
+	if t.activeTransaction {
+		if err := t.client.Flush(t.ctx); err != nil {
+			log.Errorf("Unable to flush: %v", err)
+			return err
+		}
+		if err := t.client.EndTransaction(t.ctx, kgo.TransactionEndTry(!t.abortedTransaction)); err != nil {
+			log.Errorf("Unable to end transaction: %v", err)
+			return err
+		}
+
+		log.Debugf("Ended transaction early; currentMgsProduced = %d aborted = %t", t.currentMgsProduced, t.abortedTransaction)
+
+		t.currentMgsProduced = 0
+		t.activeTransaction = false
+	}
+
+	return nil
+}
+
+// Returns true iff a new transaction was started and/or a current
+// transaction ended. This is to notify any producers that control
+// markers will be added to a partition's log.
+func (t *TransactionSTM) BeforeMessageSent() (int64, error) {
+	// EndTransaction/abort and BeginTransaction will each leave
+	// one control record in each partition's log.
+	var addedControlMarkers int64 = 0
+
+	if t.currentMgsProduced == t.config.msgsPerTransaction {
+		if err := t.client.Flush(t.ctx); err != nil {
+			log.Errorf("Unable to flush: %v", err)
+			return addedControlMarkers, err
+		}
+		if err := t.client.EndTransaction(t.ctx, kgo.TransactionEndTry(!t.abortedTransaction)); err != nil {
+			log.Errorf("Unable to end transaction: %v", err)
+			return addedControlMarkers, err
+		}
+
+		log.Debugf("Ended transaction; aborted = %t", t.abortedTransaction)
+
+		t.currentMgsProduced = 0
+		t.activeTransaction = false
+
+		addedControlMarkers += 1
+	}
+
+	// Begin new transaction if one doesn't exist
+	if !t.activeTransaction {
+		t.abortedTransaction = t.config.abortRate >= rand.Float64()
+		t.activeTransaction = true
+
+		if err := t.client.BeginTransaction(); err != nil {
+			log.Errorf("Couldn't start a transaction: %v", err)
+			return 0, err
+		}
+
+		log.Debugf("Started transaction; will abort = %t", t.abortedTransaction)
+
+		addedControlMarkers += 1
+	}
+
+	t.currentMgsProduced += 1
+	return addedControlMarkers, nil
+}
+
+func (t *TransactionSTM) InAbortedTransaction() bool {
+	return t.abortedTransaction
+}

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -86,6 +86,13 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 	opts := srw.config.workerCfg.MakeKgoOpts()
 	opts = append(opts, []kgo.Opt{
 		kgo.ConsumePartitions(offsets),
+		// By default control records are dropped by kgo.
+		// This can cause SeqReadWorker to indefinitely hang on
+		// PollFetches if control records are at the end of a
+		// partition's log. Since SeqReadWorker will never
+		// see a message at a log's HWM if kgo drops the
+		// control records.
+		kgo.KeepControlRecords(),
 	}...)
 	client, err := kgo.NewClient(opts...)
 	if err != nil {


### PR DESCRIPTION
Adds a transactional producer that produces messages in transactions. 
Questions:
- Should this be it's own producer as it is implemented here or should the existing producer should be modified to support transactions?
- Do we want a producer that can interleave transactions and regularly produced messages?