### PR TITLE
kgo-verifier: explicitly close client in seq_consumer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,18 @@ module github.com/redpanda-data/kgo-verifier
 go 1.17
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sirupsen/logrus v1.8.1
-	github.com/twmb/franz-go v1.7.1-0.20220901194750-0ca6478600c6
+	github.com/twmb/franz-go v1.9.1
 	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211116225244-e97ad6b8ef3e
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0
-	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-20211217123319-86af7226d9f0
+    github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-20211217123319-86af7226d9f0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/google/uuid v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twmb/franz-go v1.2.3-0.20211104052441-7952375c09c0/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
 github.com/twmb/franz-go v1.2.4/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
-github.com/twmb/franz-go v1.7.1-0.20220901194750-0ca6478600c6 h1:NKdixlc3wNotP3JA1NhsLcLvCPOSZy1U9qNsQmd6Ahk=
-github.com/twmb/franz-go v1.7.1-0.20220901194750-0ca6478600c6/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
+github.com/twmb/franz-go v1.9.1 h1:Wnom/Wjpb6yDmHBk8DF3wogWq2Y4kcJZJbCjdBeY3ec=
+github.com/twmb/franz-go v1.9.1/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go/pkg/kadm v0.0.0-20211116225244-e97ad6b8ef3e h1:8nkvOlltExSj///y8ZuH8jYbk9ntPwvLM8fXbbdmP5A=
 github.com/twmb/franz-go/pkg/kadm v0.0.0-20211116225244-e97ad6b8ef3e/go.mod h1:fuA2THFeFx/ms1w1R432uxWJqq7o3Q+olvJR4NFpWcM=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -52,6 +52,7 @@ func (srw *SeqReadWorker) Wait() error {
 
 	hwm := GetOffsets(client, srw.config.workerCfg.Topic, srw.config.nPartitions, -1)
 	lwm := make([]int64, srw.config.nPartitions)
+	client.Close()
 
 	for {
 		var err error
@@ -147,6 +148,7 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 	}
 
 	log.Infof("Sequential read complete up to %v (validator status %v)", last_read, srw.Status.Validator.String())
+	client.Close()
 
 	return last_read, nil
 }


### PR DESCRIPTION
From debugging of https://github.com/redpanda-data/redpanda/issues/7231 where noise from defunct clients was quite noticeable on the server side.