### PR TITLE
kgo-verifier: improve transaction verification

### DIFF
--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -123,7 +123,7 @@ func main() {
 		name := fmt.Sprintf("%s_%d_w_%d", hostName, pid, i)
 		log.Debugf("Preparing worker %s...", name)
 		wConfig := worker.NewWorkerConfig(
-			name, *brokers, *trace, *topic, *linger, *maxBufferedRecords,
+			name, *brokers, *trace, *topic, *linger, *maxBufferedRecords, *useTransactions,
 		)
 		config := repeater.NewRepeaterConfig(wConfig, *group, partitions, *keys, *payloadSize, dataInFlightPerWorker)
 		lv := repeater.NewWorker(config)

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -69,6 +69,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		SaslUser:           *username,
 		SaslPass:           *password,
 		Name:               *name,
+		Transactions:       *useTransactions,
 	}
 
 	return c

--- a/pkg/worker/repeater/repeater_worker.go
+++ b/pkg/worker/repeater/repeater_worker.go
@@ -282,14 +282,6 @@ func (v *Worker) Init() {
 			kgo.ConsumerGroup(v.config.Group),
 		}...)
 
-		if v.transactionsEnabled {
-			opts = append(opts, []kgo.Opt{
-				// By default kgo reads uncommited records and unstable offsets
-				kgo.RequireStableFetchOffsets(),
-				kgo.FetchIsolationLevel(kgo.ReadCommitted()),
-			}...)
-		}
-
 		if v.config.Group != "" {
 			opts = append(opts, kgo.ConsumerGroup(v.config.Group))
 		}

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -243,6 +243,9 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 
 			if addedControlMarkers > 0 {
 				for i, _ := range nextOffset {
+					for j := int64(0); j < int64(addedControlMarkers); j = j + 1 {
+						pw.validOffsets.Insert(p, nextOffset[i]+j)
+					}
 					nextOffset[i] += addedControlMarkers
 				}
 			}

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -75,6 +75,7 @@ func (pw *ProducerWorker) newRecord(producerId int, sequence int64) *kgo.Record 
 		// will report it as an invalid read if it's consumed. This is
 		// since messages in aborted transactions should never be read.
 		fmt.Fprintf(&key, "ABORTED MSG: %06d.%018d", producerId, sequence)
+		pw.Status.AbortedTransactionMessages += 1
 	}
 
 	payload := make([]byte, pw.config.messageSize)
@@ -106,6 +107,11 @@ type ProducerWorkerStatus struct {
 	// How many failures occured while trying to begin, abort,
 	// or commit a transaction.
 	FailedTransactions int64 `json:"failed_transactions"`
+
+	// How many messages were sent inside aborted transactions?
+	// (this is not the transaction abort count, it's the count of the messages
+	//  inside those transactions)
+	AbortedTransactionMessages int64 `json:"aborted_transaction_msgs"`
 
 	// Ack latency: a private histogram for the data,
 	// and a public summary for JSON output

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -152,6 +152,11 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 				complete[r.Partition] = true
 			}
 
+			// We subscribe to control records to make consuming-to-offset work, but we
+			// do not want to try and validate them.
+			if r.Attrs.IsControl() {
+				return
+			}
 			srw.Status.Validator.ValidateRecord(r, &validRanges)
 		})
 


### PR DESCRIPTION
Two issues seen:
- Producer writes out fragmented valid_offsets file when doing transactional production, because the control offsets aren't in the valid range.
- Consumer is not properly configured, it did not have the options to read only committed, and it _did_ have the option for reading control batches, but wasn't skipping them.

This should now work reliably for verifying a produce/consume cycle on a single partition.

The existing code was not safe for multiple partitions: it assumes that each partition start/end writes a control batch to every partition, but that is only true if the producer had written to all the partitions.  Needs further improvement.