### PR TITLE
kgo-verifier: close client in produceInner

### DIFF
--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -301,6 +301,10 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 	wg.Wait()
 	close(bad_offsets)
 
+	log.Info("Closing client...")
+	client.Close()
+	log.Info("Closed client.")
+
 	pw.produceCheckpoint()
 
 	if errored {


### PR DESCRIPTION
On "unexpected offsets" conditions, the producer
will drop out of produceInner and re-enter, to
destroy and create a client.

However, dropping the reference to the client doesn't synchronously close it, so it's possible for the
client to remain alive too long, and perhaps continue to drain its produce channel, disrupting the offset checks in the subsequent call to produceInner.

It's not certain that we've seen this happen, but it is one possibility discussed in https://github.com/redpanda-data/redpanda/issues/8289 that is straightforward to eliminate.

Related: https://github.com/redpanda-data/redpanda/issues/8289