### PR TITLE
Fix stack trace print + add explicit /print_stack endpoint

### DIFF
--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -171,6 +171,11 @@ func main() {
 		w.Write(serialized)
 	})
 
+	mux.HandleFunc("/print_stack", func(w http.ResponseWriter, r *http.Request) {
+		log.Infof("Printing stack on remote request:")
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+	})
+
 	mux.HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
 		for _, v := range verifiers {
 			v.Reset()


### PR DESCRIPTION
This was previously only printing the stack of the current goroutine.

The /print_stack endpoint enables tests to trigger a stack dump when they can detet that something has gone wrong other than a hang, such as when a consumer mysteriously drops out of a consumer group.