### PR TITLE
Compacted topics support

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -56,6 +56,7 @@ var (
 	fakeTimestampMs     = flag.Int64("fake-timestamp-ms", -1, "Producer: set artificial batch timestamps on an incrementing basis, starting from this number")
 	consumeTputMb       = flag.Int("consume-throughput-mb", -1, "Seq/group consumer: set max throughput in mb/s")
 	produceRateLimitBps = flag.Int("produce-throughput-bps", -1, "Producer: set max throughput in bytes/s")
+	keySetCardinality   = flag.Int("key-set-cardinality", -1, "Cardinality of a set of possible record keys (makes data compactible)")
 
 	useTransactions      = flag.Bool("use-transactions", false, "Producer: use a transactional producer")
 	transactionAbortRate = flag.Float64("transaction-abort-rate", 0.0, "The probability that any given transaction should abort")
@@ -187,7 +188,7 @@ func main() {
 
 	if *pCount > 0 {
 		log.Info("Starting producer...")
-		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, (*produceRateLimitBps))
+		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, (*produceRateLimitBps), *keySetCardinality)
 		pw := verifier.NewProducerWorker(pwc)
 
 		if *useTransactions {

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -20,25 +20,27 @@ import (
 )
 
 type ProducerConfig struct {
-	workerCfg       worker.WorkerConfig
-	name            string
-	nPartitions     int32
-	messageSize     int
-	messageCount    int
-	fakeTimestampMs int64
-	rateLimitBytes  int
+	workerCfg         worker.WorkerConfig
+	name              string
+	nPartitions       int32
+	messageSize       int
+	messageCount      int
+	fakeTimestampMs   int64
+	rateLimitBytes    int
+	keySetCardinality int
 }
 
 func NewProducerConfig(wc worker.WorkerConfig, name string, nPartitions int32,
-	messageSize int, messageCount int, fakeTimestampMs int64, rateLimitBytes int) ProducerConfig {
+	messageSize int, messageCount int, fakeTimestampMs int64, rateLimitBytes int, keySetCardinality int) ProducerConfig {
 	return ProducerConfig{
-		workerCfg:       wc,
-		name:            name,
-		nPartitions:     nPartitions,
-		messageCount:    messageCount,
-		messageSize:     messageSize,
-		fakeTimestampMs: fakeTimestampMs,
-		rateLimitBytes:  rateLimitBytes,
+		workerCfg:         wc,
+		name:              name,
+		nPartitions:       nPartitions,
+		messageCount:      messageCount,
+		messageSize:       messageSize,
+		fakeTimestampMs:   fakeTimestampMs,
+		rateLimitBytes:    rateLimitBytes,
+		keySetCardinality: keySetCardinality,
 	}
 }
 
@@ -73,6 +75,7 @@ func (pw *ProducerWorker) newRecord(producerId int, sequence int64) *kgo.Record 
 	var header_key bytes.Buffer
 	if !pw.transactionsEnabled || !pw.transactionSTM.InAbortedTransaction() {
 		fmt.Fprintf(&header_key, "%06d.%018d", producerId, sequence)
+
 	} else {
 		// This message ensures that `ValidatorStatus.ValidateRecord`
 		// will report it as an invalid read if it's consumed. This is
@@ -82,8 +85,18 @@ func (pw *ProducerWorker) newRecord(producerId int, sequence int64) *kgo.Record 
 	}
 
 	payload := make([]byte, pw.config.messageSize)
+	var r *kgo.Record
 
-	var r *kgo.Record = kgo.KeySliceRecord(header_key.Bytes(), payload)
+	if pw.config.keySetCardinality < 0 {
+		// by default use the same value as in record id header key
+		r = kgo.KeySliceRecord(header_key.Bytes(), payload)
+	} else {
+		// generate a random key from a set of requested cardinality
+		var key bytes.Buffer
+		fmt.Fprintf(&key, "key-%d", rand.Intn(pw.config.keySetCardinality))
+		r = kgo.KeySliceRecord(key.Bytes(), payload)
+
+	}
 
 	r.Headers = append(r.Headers, kgo.RecordHeader{Key: "KGO_VERIFIER_RECORD_ID", Value: header_key.Bytes()})
 


### PR DESCRIPTION
Added support for compacted topics in a verifier. Change the way how record identifiers are stored. This allowed to use an arbitrary value as a record key. Added command line option to generate record keys from a set of a specified cardinality. 