### PR TITLE
Use debug=2 for pprof goroutine dumps

### DIFF
--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -185,7 +185,7 @@ func main() {
 
 	mux.HandleFunc("/print_stack", func(w http.ResponseWriter, r *http.Request) {
 		log.Infof("Printing stack on remote request:")
-		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
 	})
 
 	mux.HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -175,7 +175,7 @@ func main() {
 				log.Infof("Setting a timeout of %v seconds to print the stack trace", timeoutSec)
 				go func() {
 					time.Sleep(time.Duration(timeoutSec) * time.Second)
-					pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+					pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
 				}()
 			} else {
 				log.Warn("unable to parse timeout query param, skipping printing stack trace logs")


### PR DESCRIPTION
This should get us all the goroutines, not just
a subset.