### PR TITLE
kgo-verifier: Enabled support for TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ matches offset) or not.
 
 ### Usage
 
-- Brokers must not use TLS (in BYOC that means run this script inside your k8s cluster
-  and refer to brokers by pod IP)
+- Use of TLS is allowed (through `--enable-tls`) with the caveat that the certificate
+  must be signed by a known/trusted CA (so no self-signed or self generated CAs)
 
 #### 1. Quick produce+consume smoke test: produce and then consume in the same process
 

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -39,6 +39,7 @@ var (
 	topic               = flag.String("topic", "", "topic to produce to or consume from")
 	username            = flag.String("username", "", "SASL username")
 	password            = flag.String("password", "", "SASL password")
+	enableTls           = flag.Bool("enable-tls", false, "Enables use of TLS")
 	mSize               = flag.Int("msg_size", 16384, "Size of messages to produce")
 	pCount              = flag.Int("produce_msgs", 0, "Number of messages to produce")
 	cCount              = flag.Int("rand_read_msgs", 0, "Number of validation reads to do from each random reader")
@@ -76,6 +77,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		BatchMaxbytes:       uint(*batchMaxBytes),
 		SaslUser:            *username,
 		SaslPass:            *password,
+		UseTls:              *enableTls,
 		Name:                *name,
 		Transactions:        *useTransactions,
 		CompressionType:     *compressionType,


### PR DESCRIPTION
Utilized the TLS dialer to enable TLS support for kgo-verifier. Caveat: Must use a 'known' CA to sign certificates, or add your CA to the OS's list of good CAs.