### PR TITLE
worker/repeater: Remove override of compression

### DIFF
--- a/pkg/worker/repeater/repeater_worker.go
+++ b/pkg/worker/repeater/repeater_worker.go
@@ -291,7 +291,6 @@ func (v *Worker) Init() {
 
 		opts = append(opts, []kgo.Opt{
 			kgo.ProducerBatchMaxBytes(1024 * 1024),
-			kgo.ProducerBatchCompression(kgo.NoCompression()),
 			kgo.RecordPartitioner(kgo.StickyKeyPartitioner(nil)),
 		}...)
 


### PR DESCRIPTION
ProducerBatchCompression is provided by the worker config but was being overridden to NoCompression.  Remove that line