### PR TITLE
status: Added topic name to status

### DIFF
--- a/pkg/worker/repeater/repeater_worker.go
+++ b/pkg/worker/repeater/repeater_worker.go
@@ -120,6 +120,7 @@ type LatencyReport struct {
 }
 
 type WorkerStatus struct {
+	Topic    string        `json:"topic"`
 	Produced int64         `json:"produced"`
 	Consumed int64         `json:"consumed"`
 	Enqueued int           `json:"enqueued"`
@@ -133,6 +134,7 @@ type WorkerStatus struct {
  */
 func (v *Worker) Status() WorkerStatus {
 	return WorkerStatus{
+		Topic:    v.config.workerCfg.Topic,
 		Produced: v.totalProduced,
 		Consumed: v.totalConsumed,
 		Enqueued: len(v.pending),

--- a/pkg/worker/verifier/group_read_worker.go
+++ b/pkg/worker/verifier/group_read_worker.go
@@ -36,6 +36,7 @@ func NewGroupReadConfig(
 }
 
 type GroupWorkerStatus struct {
+	Topic     string          `json:"topic"`
 	Validator ValidatorStatus `json:"validator"`
 	Active    bool            `json:"active"`
 	Errors    int             `json:"errors"`
@@ -50,7 +51,7 @@ type GroupReadWorker struct {
 func NewGroupReadWorker(cfg GroupReadConfig) GroupReadWorker {
 	return GroupReadWorker{
 		config: cfg,
-		Status: GroupWorkerStatus{},
+		Status: GroupWorkerStatus{Topic: cfg.workerCfg.Topic},
 	}
 }
 
@@ -250,7 +251,7 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 }
 
 func (grw *GroupReadWorker) ResetStats() {
-	grw.Status = GroupWorkerStatus{}
+	grw.Status = GroupWorkerStatus{Topic: grw.config.workerCfg.Topic}
 }
 
 func (grw *GroupReadWorker) GetStatus() interface{} {

--- a/pkg/worker/verifier/random_read_worker.go
+++ b/pkg/worker/verifier/random_read_worker.go
@@ -26,6 +26,7 @@ type RandomReadWorker struct {
 }
 
 type RandomWorkerStatus struct {
+	Topic     string          `json:"topic"`
 	Validator ValidatorStatus `json:"validator"`
 	Active    bool            `json:"active"`
 	Errors    int             `json:"errors"`
@@ -43,7 +44,7 @@ func NewRandomReadConfig(wc worker.WorkerConfig, name string, nPartitions int32,
 func NewRandomReadWorker(cfg RandomReadConfig) RandomReadWorker {
 	return RandomReadWorker{
 		config: cfg,
-		Status: RandomWorkerStatus{},
+		Status: RandomWorkerStatus{Topic: cfg.workerCfg.Topic},
 	}
 }
 
@@ -170,7 +171,7 @@ func (w *RandomReadWorker) Wait() error {
 }
 
 func (rrw *RandomReadWorker) ResetStats() {
-	rrw.Status = RandomWorkerStatus{}
+	rrw.Status = RandomWorkerStatus{Topic: rrw.config.workerCfg.Topic}
 }
 
 func (rrw *RandomReadWorker) GetStatus() interface{} {

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -30,6 +30,7 @@ func NewSeqReadConfig(
 }
 
 type SeqWorkerStatus struct {
+	Topic     string          `json:"topic"`
 	Validator ValidatorStatus `json:"validator"`
 	Active    bool            `json:"active"`
 	Errors    int             `json:"errors"`
@@ -43,7 +44,7 @@ type SeqReadWorker struct {
 func NewSeqReadWorker(cfg SeqReadConfig) SeqReadWorker {
 	return SeqReadWorker{
 		config: cfg,
-		Status: SeqWorkerStatus{},
+		Status: SeqWorkerStatus{Topic: cfg.workerCfg.Topic},
 	}
 }
 
@@ -184,7 +185,7 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 }
 
 func (srw *SeqReadWorker) ResetStats() {
-	srw.Status = SeqWorkerStatus{}
+	srw.Status = SeqWorkerStatus{Topic: srw.config.workerCfg.Topic}
 }
 
 func (srw *SeqReadWorker) GetStatus() interface{} {


### PR DESCRIPTION
This change was prompted by testing on the LRC.  We have multiple instances of kgo* running, so in order to keep track of which topic, I added the topic name to the status structures.