### PR TITLE
kgo-verifier: fix status map race and make timestamp step configurable

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -55,6 +55,7 @@ var (
 	loop                = flag.Bool("loop", false, "For readers, run indefinitely until stopped via signal or HTTP call")
 	name                = flag.String("client-name", "kgo", "Name of kafka client")
 	fakeTimestampMs     = flag.Int64("fake-timestamp-ms", -1, "Producer: set artificial batch timestamps on an incrementing basis, starting from this number")
+	fakeTimestampStepMs = flag.Int64("fake-timestamp-step-ms", 1, "Producer: step size used to increment fake timestamp")
 	consumeTputMb       = flag.Int("consume-throughput-mb", -1, "Seq/group consumer: set max throughput in mb/s")
 	produceRateLimitBps = flag.Int("produce-throughput-bps", -1, "Producer: set max throughput in bytes/s")
 	keySetCardinality   = flag.Int("key-set-cardinality", -1, "Cardinality of a set of possible record keys (makes data compactible)")
@@ -207,7 +208,7 @@ func main() {
 
 	if *pCount > 0 {
 		log.Info("Starting producer...")
-		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, (*produceRateLimitBps), *keySetCardinality)
+		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, *fakeTimestampStepMs, (*produceRateLimitBps), *keySetCardinality)
 		pw := verifier.NewProducerWorker(pwc)
 
 		if *useTransactions {

--- a/pkg/worker/verifier/group_read_worker.go
+++ b/pkg/worker/verifier/group_read_worker.go
@@ -254,6 +254,6 @@ func (grw *GroupReadWorker) ResetStats() {
 	grw.Status = GroupWorkerStatus{Topic: grw.config.workerCfg.Topic}
 }
 
-func (grw *GroupReadWorker) GetStatus() interface{} {
-	return &grw.Status
+func (grw *GroupReadWorker) GetStatus() (interface{}, *sync.Mutex) {
+	return &grw.Status, &grw.Status.Validator.lock
 }

--- a/pkg/worker/verifier/random_read_worker.go
+++ b/pkg/worker/verifier/random_read_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/redpanda-data/kgo-verifier/pkg/util"
@@ -174,6 +175,6 @@ func (rrw *RandomReadWorker) ResetStats() {
 	rrw.Status = RandomWorkerStatus{Topic: rrw.config.workerCfg.Topic}
 }
 
-func (rrw *RandomReadWorker) GetStatus() interface{} {
-	return &rrw.Status
+func (rrw *RandomReadWorker) GetStatus() (interface{}, *sync.Mutex) {
+	return &rrw.Status, &rrw.Status.Validator.lock
 }

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -2,6 +2,7 @@ package verifier
 
 import (
 	"context"
+	"sync"
 
 	worker "github.com/redpanda-data/kgo-verifier/pkg/worker"
 	log "github.com/sirupsen/logrus"
@@ -188,6 +189,6 @@ func (srw *SeqReadWorker) ResetStats() {
 	srw.Status = SeqWorkerStatus{Topic: srw.config.workerCfg.Topic}
 }
 
-func (srw *SeqReadWorker) GetStatus() interface{} {
-	return &srw.Status
+func (srw *SeqReadWorker) GetStatus() (interface{}, *sync.Mutex) {
+	return &srw.Status, &srw.Status.Validator.lock
 }

--- a/pkg/worker/verifier/validator_status.go
+++ b/pkg/worker/verifier/validator_status.go
@@ -65,9 +65,9 @@ func (cs *ValidatorStatus) ValidateRecord(r *kgo.Record, validRanges *TopicOffse
 		cs.ValidReads += 1
 		log.Debugf("Read OK (%s) on p=%d at o=%d", r.Headers[0].Value, r.Partition, r.Offset)
 
-        if cs.MaxOffsetsConsumed == nil {
-            cs.MaxOffsetsConsumed = make(map[int32]int64)
-        }
+		if cs.MaxOffsetsConsumed == nil {
+			cs.MaxOffsetsConsumed = make(map[int32]int64)
+		}
 
 		currentMax, present := cs.MaxOffsetsConsumed[r.Partition]
 		if present {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	metrics "github.com/rcrowley/go-metrics"
@@ -90,7 +91,7 @@ func (ms *MessageStats) Reset() {
 }
 
 type Worker interface {
-	GetStatus() interface{}
+	GetStatus() (interface{}, *sync.Mutex)
 	ResetStats()
 }
 


### PR DESCRIPTION
This PR does two things:
1. Fix races on accessing the HWM maps in the worker status
2. Make the timestamp step configurable when producing with custom timestamps