### PR TITLE
kgo-verifier: require go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/kgo-verifier
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
Discovered that this requires 1.19 to build now. So the mod file should indicate that.