### PR TITLE
panic if the listener for remote control can not be started

### DIFF
--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -219,7 +219,12 @@ func main() {
 		w.Write(make([]byte, 0))
 	})
 
-	go http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *remotePort), mux)
+	go func() {
+		listenAddr := fmt.Sprintf("0.0.0.0:%d", *remotePort)
+		if err := http.ListenAndServe(listenAddr, mux); err != nil {
+			panic(fmt.Sprintf("failed to listen on %s: %v", listenAddr, err));
+		}
+	}();
 
 	if !*remote {
 		admin, err := NewAdmin()

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -205,7 +205,12 @@ func main() {
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	})
 
-	go http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *remotePort), mux)
+	go func() {
+		listenAddr := fmt.Sprintf("0.0.0.0:%d", *remotePort)
+		if err := http.ListenAndServe(listenAddr, mux); err != nil {
+			panic(fmt.Sprintf("failed to listen on %s: %v", listenAddr, err));
+		}
+	}();
 
 	if *pCount > 0 {
 		log.Info("Starting producer...")


### PR DESCRIPTION
Due to test infra issues we've had these services started where previous instances were already running leading to very hard to debug results.

Panic right away instead of silently ignoring the error.

I'm choosing to do it in the most simple way as a graceful server shutdown is not required for the use-cases on these services.

Before:

```
 → ./kgo-verifier -topic aba -debug -produce_msgs 10
INFO[0000] Getting topic metadata...
DEBU[0000] Targeting topic aba with 1 partitions
INFO[0000] Starting producer...
...
DEBU[0000] Writing partition 0 at 50
...
INFO[0000] Finished producer.
```

After:

```
 → ./kgo-verifier -topic aba -debug -produce_msgs 10
INFO[0000] Getting topic metadata...
DEBU[0000] Targeting topic aba with 1 partitions
INFO[0000] Starting producer...
INFO[0000] Loading offsets for topic aba t=-1...
panic: failed to listen on 0.0.0.0:7884: listen tcp 0.0.0.0:7884: bind: address already in use
```