### PR TITLE
kgo: run one extra pass after /last_pass request

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -236,9 +236,14 @@ func main() {
 		workers = append(workers, &srw)
 
 		firstPass := true
-		for firstPass || (len(lastPassChan) == 0 && *loop) {
+		lastPass := false
+		for firstPass || (!lastPass && *loop) {
 			log.Info("Starting sequential read pass")
 			firstPass = false
+			lastPass = len(lastPassChan) != 0
+			if lastPass {
+				log.Info("This will be the last pass")
+			}
 			waitErr := srw.Wait()
 			if waitErr != nil {
 				// Proceed around the loop, to be tolerant of e.g. kafka client
@@ -288,8 +293,13 @@ func main() {
 		workers = append(workers, &grw)
 
 		firstPass := true
-		for firstPass || (len(lastPassChan) == 0 && *loop) {
+		lastPass := false
+		for firstPass || (!lastPass && *loop) {
 			log.Info("Starting group read pass")
+			lastPass = len(lastPassChan) == 0
+			if lastPass {
+				log.Info("This will be the last pass")
+			}
 			firstPass = false
 			waitErr := grw.Wait()
 			util.Chk(waitErr, "Consumer error: %v", err)


### PR DESCRIPTION
This is being invoked by stress tests which run consumers in a loop but want to ensure at the end that all the data was read.

kgo first requests high topic watermark, then starts routines that read up to that watermark. If the last run begins before all the data is written, then `/last_pass` is called, it will exit without having a chance to read all the data.

This is for https://github.com/redpanda-data/redpanda/issues/12109