### PR TITLE
Added option to configure `acks` that kgo verifier producer will use

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 func Die(msg string, args ...interface{}) {
@@ -69,4 +70,15 @@ func (ls *loopState) Next() bool {
 	}
 
 	return true
+}
+
+func MakeAcks(acks int) (kgo.Acks, error) {
+	if acks == -1 {
+		return kgo.AllISRAcks(), nil
+	} else if acks == 1 {
+		return kgo.LeaderAck(), nil
+	} else if acks == 0 {
+		return kgo.NoAck(), nil
+	}
+	return kgo.Acks{}, fmt.Errorf("Invalid acks %d, values supported is -1, 0, 1.", acks)
 }

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -254,7 +254,6 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 	opts := pw.config.workerCfg.MakeKgoOpts()
 
 	opts = append(opts, []kgo.Opt{
-		kgo.RequiredAcks(kgo.AllISRAcks()),
 		kgo.RecordPartitioner(kgo.ManualPartitioner()),
 	}...)
 


### PR DESCRIPTION
Added option to use relaxed consistency writes when producing in KgoVerfier application. This change is going to fill the feature gap between the KgoVerifier and VerifiableProducer that we use in tests. 