### PR TITLE
verifier: tolerate data loss

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+name: Go
+
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 'stable' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Display Go version
+        run: go version
+      - name: Test & Build
+        run: make

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ kgo-verifier
 valid_offsets*.json
 
 .idea
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 
-all: build
+all: test build
 
 build: build-verifier build-repeater
+
+test:
+	go test -v ./...
 
 build-verifier:
 	go build -o kgo-verifier cmd/kgo-verifier/main.go

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -53,7 +53,8 @@ var (
 	maxBufferedRecords  = flag.Uint("max-buffered-records", 1024, "Producer buffer size: the default of 1 is makes roughly one event per batch, useful for measurement.  Set to something higher to make it easier to max out bandwidth.")
 	remote              = flag.Bool("remote", false, "Remote control mode, driven by HTTP calls, for use in automated tests")
 	remotePort          = flag.Uint("remote-port", 7884, "HTTP listen port for remote control/query")
-	loop                = flag.Bool("loop", false, "For readers, run indefinitely until stopped via signal or HTTP call")
+	loop                = flag.Bool("loop", false, "For readers, repeatedly consume from the beginning, looping to the beginning after hitting the end of the topic until stopped via signal")
+	continuous          = flag.Bool("continuous", false, "For readers, wait for new messages to arrive after hitting the end of the topic until stopped via signal or HTTP call")
 	name                = flag.String("client-name", "kgo", "Name of kafka client")
 	fakeTimestampMs     = flag.Int64("fake-timestamp-ms", -1, "Producer: set artificial batch timestamps on an incrementing basis, starting from this number")
 	fakeTimestampStepMs = flag.Int64("fake-timestamp-step-ms", 1, "Producer: step size used to increment fake timestamp")
@@ -85,6 +86,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		Transactions:        *useTransactions,
 		CompressionType:     *compressionType,
 		CompressiblePayload: *compressiblePayload,
+		Continuous:          *continuous,
 	}
 
 	return c
@@ -221,10 +223,19 @@ func main() {
 		}
 	}()
 
+	if *loop && *continuous {
+		util.Die("Cannot use -loop and -continuous together")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 	loopState := util.NewLoopState(*loop)
 	go func() {
 		<-lastPassChan
-		loopState.RequestLastPass()
+		if *continuous {
+			cancel()
+		} else {
+			loopState.RequestLastPass()
+		}
 	}()
 
 	if *pCount > 0 {
@@ -250,7 +261,7 @@ func main() {
 
 		for loopState.Next() {
 			log.Info("Starting sequential read pass")
-			waitErr := srw.Wait()
+			waitErr := srw.Wait(ctx)
 			if waitErr != nil {
 				// Proceed around the loop, to be tolerant of e.g. kafka client
 				// construct failures on unavailable cluster
@@ -298,7 +309,7 @@ func main() {
 
 		for loopState.Next() {
 			log.Info("Starting group read pass")
-			waitErr := grw.Wait()
+			waitErr := grw.Wait(ctx)
 			util.Chk(waitErr, "Consumer error: %v", err)
 		}
 	}

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -69,6 +69,8 @@ var (
 
 	compressionType     = flag.String("compression-type", "", "One of none, gzip, snappy, lz4, zstd, or 'mixed' to pick a random codec for each producer")
 	compressiblePayload = flag.Bool("compressible-payload", false, "If true, use a highly compressible payload instead of the default random payload")
+
+	tolerateDataLoss = flag.Bool("tolerate-data-loss", false, "If true, tolerate data-loss events")
 )
 
 func makeWorkerConfig() worker.WorkerConfig {
@@ -86,6 +88,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		Transactions:        *useTransactions,
 		CompressionType:     *compressionType,
 		CompressiblePayload: *compressiblePayload,
+		TolerateDataLoss:    *tolerateDataLoss,
 		Continuous:          *continuous,
 	}
 

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -180,7 +180,11 @@ func main() {
 
 	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
 		log.Info("Remote request /shutdown")
-		shutdownChan <- 1
+		select {
+		case shutdownChan <- 1:
+		default:
+			log.Warn("shutdown channel is full, skipping")
+		}
 	})
 
 	mux.HandleFunc("/last_pass", func(w http.ResponseWriter, r *http.Request) {
@@ -198,7 +202,11 @@ func main() {
 				log.Warn("unable to parse timeout query param, skipping printing stack trace logs")
 			}
 		}
-		lastPassChan <- 1
+		select {
+		case lastPassChan <- 1:
+		default:
+			log.Warn("last_pass channel is full, skipping")
+		}
 	})
 
 	mux.HandleFunc("/print_stack", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -227,9 +227,7 @@ func main() {
 		waitErr := pw.Wait()
 		util.Chk(err, "Producer error: %v", waitErr)
 		log.Info("Finished producer.")
-	}
-
-	if *seqRead {
+	} else if *seqRead {
 		srw := verifier.NewSeqReadWorker(verifier.NewSeqReadConfig(
 			makeWorkerConfig(), "sequential", nPartitions, *seqConsumeCount,
 			(*consumeTputMb)*1024*1024,
@@ -252,9 +250,7 @@ func main() {
 				log.Warnf("Error from sequeqntial read worker: %v", err)
 			}
 		}
-	}
-
-	if *cCount > 0 {
+	} else if *cCount > 0 {
 		var wg sync.WaitGroup
 		var randomWorkers []*verifier.RandomReadWorker
 		for i := 0; i < *parallelRead; i++ {
@@ -289,9 +285,7 @@ func main() {
 			}
 			wg.Wait()
 		}
-	}
-
-	if *cgReaders > 0 {
+	} else if *cgReaders > 0 {
 		if *loop && *cgName != "" {
 			util.Die("Cannot use -loop and -consumer_group_name together")
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,13 +1,12 @@
-
 package util
 
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
-
 
 func Die(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
@@ -19,4 +18,55 @@ func Chk(err error, msg string, args ...interface{}) {
 	if err != nil {
 		Die(msg, args...)
 	}
+}
+
+// loopState is a helper struct holding common state for managing consumer loops.
+type loopState struct {
+	mu sync.RWMutex
+
+	// `loop` is set to false when looping should stop. If it is false initially
+	// then `Next()` must return true at least once.
+	// To achieve that, we set lastPass to true to indicate that Next() returned
+	// true at least once when `loop` was false and on the next run we know that
+	// we are done and need to fuse the state.
+	loop     bool
+	lastPass bool
+
+	// fused is set to true after Next returns false. It is used to enforce
+	// the invariant that Next must not be called after it returned false
+	// previously.
+	fused bool
+}
+
+// NewLoopState creates a state object for managing a consumer loops.
+func NewLoopState(loop bool) *loopState {
+	return &loopState{loop: loop}
+}
+
+// RequestLastPass requests for the loop to run one more time before exiting.
+func (ls *loopState) RequestLastPass() {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	ls.loop = false
+}
+
+// Next returns true if current loop iteration should run.
+func (ls *loopState) Next() bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	if ls.fused {
+		panic("invariant: Next must not be called after it returned false previously")
+	}
+
+	if ls.lastPass {
+		ls.fused = true
+		return false
+	} else if !ls.loop {
+		log.Info("This is the last pass.")
+		ls.lastPass = true
+	}
+
+	return true
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,62 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/kgo-verifier/pkg/util"
+)
+
+func TestLoopStateDefault(t *testing.T) {
+	s := util.NewLoopState(false)
+	if !s.Next() {
+		t.Error("Next must returns true on first pass")
+	}
+	if s.Next() {
+		t.Error("Next must return false after first pass")
+	}
+}
+
+func TestLoopStateDoLoop(t *testing.T) {
+	s := util.NewLoopState(true)
+	for i := 0; i < 3; i++ {
+		if !s.Next() {
+			t.Error("Next must return true as long as Loop is set to true")
+		}
+	}
+	s.RequestLastPass()
+	if !s.Next() {
+		t.Error("Next must return true after RequestLastPass")
+	}
+	if s.Next() {
+		t.Error("Next must return false after RequestLastPass")
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Next must panic after RequestLastPass and third Next call")
+			}
+		}()
+		s.Next()
+	}()
+}
+
+func TestLoopStateDoLoopStopImmediately(t *testing.T) {
+	s := util.NewLoopState(true)
+	s.RequestLastPass()
+	if !s.Next() {
+		t.Error("Next must return true after RequestLastPass")
+	}
+	if s.Next() {
+		t.Error("Next must return false after RequestLastPass")
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Next must panic after RequestLastPass and third Next call")
+			}
+		}()
+		s.Next()
+	}()
+}

--- a/pkg/worker/repeater/repeater_worker.go
+++ b/pkg/worker/repeater/repeater_worker.go
@@ -260,7 +260,7 @@ func (v *Worker) ConsumeRecord(r *kgo.Record) {
 
 	v.globalStats.E2e_latency.Update(e2e_latency)
 
-	log.Debugf("Consume %s token %06d, total latency %s", v.config.workerCfg.Name, token, e2e_latency)
+	log.Debugf("Consume %s token %06d, total latency %v", v.config.workerCfg.Name, token, e2e_latency)
 	v.pending <- int64(token)
 }
 
@@ -495,7 +495,7 @@ loop:
 		})
 
 	}
-	log.Debug("Consume %s dropping out", v.config.workerCfg.Name)
+	log.Debugf("Consume %s dropping out", v.config.workerCfg.Name)
 
 	sync_ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	v.client.CommitUncommittedOffsets(sync_ctx)

--- a/pkg/worker/verifier/group_read_worker.go
+++ b/pkg/worker/verifier/group_read_worker.go
@@ -2,6 +2,7 @@ package verifier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -253,7 +254,13 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 			log.Warnf(
 				"fiber %v: Consumer group fetch %s/%d e=%v...",
 				fiberId, t, p, err)
-			r_err = err
+			var lossErr *kgo.ErrDataLoss
+			if grw.config.workerCfg.TolerateDataLoss && errors.As(err, &lossErr) {
+				grw.Status.Validator.RecordLostOffsets(lossErr.Partition, lossErr.ConsumedTo-lossErr.ResetTo)
+				grw.Status.Validator.SetMonotonicityTestStateForPartition(p, lossErr.ResetTo-1)
+			} else {
+				r_err = err
+			}
 		})
 
 		if r_err != nil {

--- a/pkg/worker/verifier/group_read_worker.go
+++ b/pkg/worker/verifier/group_read_worker.go
@@ -15,7 +15,7 @@ import (
 
 type GroupReadConfig struct {
 	workerCfg      worker.WorkerConfig
-	name           string
+	groupName      string
 	nPartitions    int32
 	nReaders       int
 	maxReadCount   int
@@ -27,7 +27,7 @@ func NewGroupReadConfig(
 	maxReadCount int, rateLimitBytes int) GroupReadConfig {
 	return GroupReadConfig{
 		workerCfg:      wc,
-		name:           name,
+		groupName:      name,
 		nPartitions:    nPartitions,
 		nReaders:       nReaders,
 		maxReadCount:   maxReadCount,
@@ -154,8 +154,12 @@ func (grw *GroupReadWorker) Wait() error {
 		return nil
 	}
 
-	groupName := fmt.Sprintf(
-		"kgo-verifier-%d-%d-%d", time.Now().Unix(), os.Getpid(), grw.Status.runCount)
+	groupName := grw.config.groupName
+	if grw.config.groupName == "" {
+		groupName = fmt.Sprintf(
+			"kgo-verifier-%d-%d-%d", time.Now().Unix(), os.Getpid(), grw.Status.runCount)
+	}
+
 	grw.Status.runCount += 1
 
 	log.Infof("Reading with consumer group %s", groupName)

--- a/pkg/worker/verifier/offset_ranges_test.go
+++ b/pkg/worker/verifier/offset_ranges_test.go
@@ -1,0 +1,109 @@
+package verifier_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/redpanda-data/kgo-verifier/pkg/worker/verifier"
+)
+
+func TestOffsetRanges(t *testing.T) {
+	r := verifier.OffsetRanges{}
+	r.Insert(0)
+	r.Insert(1)
+	r.Insert(2)
+	r.Insert(10)
+}
+
+func TestOffsetRangesOutOfOrder(t *testing.T) {
+	r := verifier.OffsetRanges{}
+	r.Insert(0)
+	r.Insert(4)
+	r.Insert(5)
+	r.Insert(6)
+	r.Insert(10)
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected to panic on out of order insert")
+			}
+		}()
+		r.Insert(3)
+	}()
+
+}
+
+func TestOffsetRangesTolerateOutOfOrderContinuous(t *testing.T) {
+	r := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	r.Insert(0)
+	r.Insert(4)
+	r.Insert(5)
+	r.Insert(6)
+	r.Insert(10)
+
+	// This will truncate the ranges.
+	r.Insert(5)
+
+	expected := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	expected.Insert(0)
+	expected.Insert(4)
+	expected.Insert(5)
+
+	if !reflect.DeepEqual(expected, r) {
+		t.Errorf("Expected %v, got %v", expected, r.Ranges)
+	}
+}
+
+func TestOffsetRangesTolerateOutOfOrderGaps(t *testing.T) {
+	r := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	r.Insert(0)
+	r.Insert(3)
+	r.Insert(5)
+	r.Insert(7)
+	r.Insert(10)
+
+	// This will truncate the ranges.
+	r.Insert(5)
+
+	expected := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	expected.Insert(0)
+	expected.Insert(3)
+	expected.Insert(5)
+
+	if !reflect.DeepEqual(expected, r) {
+		t.Errorf("Expected %v, got %v", expected, r.Ranges)
+	}
+}
+
+func TestOffsetRangesTolerateOutOfOrderInsideGap(t *testing.T) {
+	r := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	r.Insert(0)
+	r.Insert(3)
+	r.Insert(7)
+	r.Insert(10)
+
+	// This will truncate the ranges.
+	r.Insert(5)
+
+	expected := verifier.OffsetRanges{
+		TolerateDataLoss: true,
+	}
+	expected.Insert(0)
+	expected.Insert(3)
+	expected.Insert(5)
+
+	if !reflect.DeepEqual(expected, r) {
+		t.Errorf("Expected %v, got %v", expected, r)
+	}
+}

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -342,7 +342,7 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 				pw.Status.OnBadOffset()
 				bad_offsets <- BadOffset{r.Partition, r.Offset}
 				errored = true
-				log.Debugf("errored = %b", errored)
+				log.Debugf("errored = %t", errored)
 			} else {
 				ackLatency := time.Now().Sub(sentAt)
 				pw.Status.OnAcked(r.Partition, r.Offset)

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -49,28 +49,31 @@ func NewSeqReadWorker(cfg SeqReadConfig) SeqReadWorker {
 	}
 }
 
-func (srw *SeqReadWorker) Wait() error {
+func (srw *SeqReadWorker) Wait(ctx context.Context) error {
 	srw.Status.Active = true
 	defer func() { srw.Status.Active = false }()
 
-	client, err := kgo.NewClient(srw.config.workerCfg.MakeKgoOpts()...)
-	if err != nil {
-		log.Errorf("Error constructing client: %v", err)
-		return err
-	}
-
-	hwm := GetOffsets(client, srw.config.workerCfg.Topic, srw.config.nPartitions, -1)
 	lwm := make([]int64, srw.config.nPartitions)
-	client.Close()
+	var hwm []int64
+
+	if !srw.config.workerCfg.Continuous {
+		client, err := kgo.NewClient(srw.config.workerCfg.MakeKgoOpts()...)
+		if err != nil {
+			log.Errorf("Error constructing client: %v", err)
+			return err
+		}
+		hwm = GetOffsets(client, srw.config.workerCfg.Topic, srw.config.nPartitions, -1)
+		client.Close()
+	}
 
 	for {
 		var err error
-		lwm, err = srw.sequentialReadInner(lwm, hwm)
-		if err != nil {
+		lwm, err = srw.sequentialReadInner(ctx, lwm, hwm)
+		if err == nil || ctx.Err() == context.Canceled {
+			break
+		} else if err != nil {
 			log.Warnf("Restarting reader for error %v", err)
 			// Loop around
-		} else {
-			break
 		}
 	}
 
@@ -79,7 +82,7 @@ func (srw *SeqReadWorker) Wait() error {
 	return nil
 }
 
-func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]int64, error) {
+func (srw *SeqReadWorker) sequentialReadInner(ctx context.Context, startAt []int64, upTo []int64) ([]int64, error) {
 	log.Infof("Sequential read start offsets: %v", startAt)
 	log.Infof("Sequential read end offsets: %v", upTo)
 
@@ -89,8 +92,10 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 	for i, o := range startAt {
 		partOffsets[int32(i)] = kgo.NewOffset().At(o)
 		log.Infof("Sequential start offset %s/%d  %#v...", srw.config.workerCfg.Topic, i, partOffsets[int32(i)])
-		if o == upTo[i] {
-			complete[i] = true
+		if len(upTo) > 0 {
+			if o == upTo[i] {
+				complete[i] = true
+			}
 		}
 	}
 	offsets[srw.config.workerCfg.Topic] = partOffsets
@@ -128,7 +133,7 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 
 	for {
 		log.Debugf("Calling PollFetches (lwm=%v status %s)", lwm, srw.Status.Validator.String())
-		fetches := client.PollFetches(context.Background())
+		fetches := client.PollFetches(ctx)
 		log.Debugf("PollFetches returned %d fetches", len(fetches))
 
 		var r_err error
@@ -146,7 +151,7 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 
 		fetches.EachRecord(func(r *kgo.Record) {
 			if rlimiter != nil {
-				rlimiter.WaitN(context.Background(), len(r.Value))
+				rlimiter.WaitN(ctx, len(r.Value))
 			}
 
 			log.Debugf("Sequential read %s/%d o=%d...", srw.config.workerCfg.Topic, r.Partition, r.Offset)
@@ -157,8 +162,10 @@ func (srw *SeqReadWorker) sequentialReadInner(startAt []int64, upTo []int64) ([]
 				lwm[r.Partition] = r.Offset + 1
 			}
 
-			if r.Offset >= upTo[r.Partition]-1 {
-				complete[r.Partition] = true
+			if len(upTo) > 0 {
+				if r.Offset >= upTo[r.Partition]-1 {
+					complete[r.Partition] = true
+				}
 			}
 
 			// We subscribe to control records to make consuming-to-offset work, but we

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -156,6 +156,8 @@ type WorkerConfig struct {
 	// If true, use a payload that compresses easily.  If false, use an
 	// incompressible payload.
 	CompressiblePayload bool
+
+	Continuous bool
 }
 
 func CompressionCodecFromString(s string) (kgo.CompressionCodec, error) {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -157,6 +157,7 @@ type WorkerConfig struct {
 	// incompressible payload.
 	CompressiblePayload bool
 
+	TolerateDataLoss bool
 	Continuous bool
 }
 


### PR DESCRIPTION
* Introduce a `-continuous` flag which instructs kgo-verifier to continue polling for new data rather than exiting or looping.
* Introduce a `-tolerate-data-loss` flag which facilitates testing write caching feature where data loss is tolerable in specific circumstances.