### PR TITLE
go-verifier: add an option to commit offsets right after fetch 

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -49,6 +49,7 @@ var (
 	batchMaxBytes       = flag.Int("batch_max_bytes", 1048576, "the maximum batch size to allow per-partition (must be less than Kafka's max.message.bytes, producing)")
 	cgReaders           = flag.Int("consumer_group_readers", 0, "Number of parallel readers in the consumer group")
 	cgName              = flag.String("consumer_group_name", "", "The name of the consumer group. Generated randomly if not set.")
+	cgCommitAfterFetch  = flag.Bool("commit-after-fetch", false, "Whether to commit offsets after fetching records rather than relying on auto-commit")
 	linger              = flag.Duration("linger", 0, "if non-zero, linger to use when producing")
 	maxBufferedRecords  = flag.Uint("max-buffered-records", 1024, "Producer buffer size: the default of 1 is makes roughly one event per batch, useful for measurement.  Set to something higher to make it easier to max out bandwidth.")
 	remote              = flag.Bool("remote", false, "Remote control mode, driven by HTTP calls, for use in automated tests")
@@ -307,7 +308,7 @@ func main() {
 		grw := verifier.NewGroupReadWorker(
 			verifier.NewGroupReadConfig(
 				makeWorkerConfig(), *cgName, nPartitions, *cgReaders,
-				*seqConsumeCount, (*consumeTputMb)*1024*1024))
+				*seqConsumeCount, (*consumeTputMb)*1024*1024, *cgCommitAfterFetch))
 		workers = append(workers, &grw)
 
 		for loopState.Next() {

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -315,6 +315,8 @@ func main() {
 			waitErr := grw.Wait(ctx)
 			util.Chk(waitErr, "Consumer error: %v", err)
 		}
+	} else {
+		util.Die("No valid operation specified (use one of -produce_msgs, -rand_read_msgs , -seq_read, -consumer_group_readers)")
 	}
 
 	if *remote {


### PR DESCRIPTION
By default we commit every 5s which is a slow for tests.