### PR TITLE
Compaction verification enhancements

### DIFF
--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -73,7 +73,8 @@ var (
 	tolerateDataLoss      = flag.Bool("tolerate-data-loss", false, "If true, tolerate data-loss events")
 	tolerateFailedProduce = flag.Bool("tolerate-failed-produce", false, "If true, tolerate and retry failed produce")
 	tombstoneProbability  = flag.Float64("tombstone-probability", 0.0, "The probability (between 0.0 and 1.0) that a record produced is a tombstone record.")
-	compacted             = flag.Bool("compacted", false, "Whether the topic to be verified is compacted or not.")
+	compacted             = flag.Bool("compacted", false, "Whether the topic to be verified is compacted or not. This will suppress warnings about offset gaps in consumed values.")
+	validateLatestValues  = flag.Bool("validate-latest-values", false, "If true, values consumed by a worker will be validated against the last produced value by a producer. This value should only be set if compaction has been allowed to fully de-duplicate the entirety of the log before consuming.")
 )
 
 func makeWorkerConfig() worker.WorkerConfig {
@@ -94,6 +95,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		TolerateDataLoss:      *tolerateDataLoss,
 		TolerateFailedProduce: *tolerateFailedProduce,
 		Continuous:            *continuous,
+		ValidateLatestValues:  *validateLatestValues,
 	}
 
 	return c
@@ -263,7 +265,7 @@ func main() {
 		srw := verifier.NewSeqReadWorker(verifier.NewSeqReadConfig(
 			makeWorkerConfig(), "sequential", nPartitions, *seqConsumeCount,
 			(*consumeTputMb)*1024*1024,
-		), verifier.NewValidatorStatus(*compacted))
+		), verifier.NewValidatorStatus(*compacted, *validateLatestValues, *topic, nPartitions))
 		workers = append(workers, &srw)
 
 		for loopState.Next() {
@@ -282,7 +284,7 @@ func main() {
 			workerCfg := verifier.NewRandomReadConfig(
 				makeWorkerConfig(), fmt.Sprintf("random-%03d", i), nPartitions, *cCount,
 			)
-			worker := verifier.NewRandomReadWorker(workerCfg, verifier.NewValidatorStatus(*compacted))
+			worker := verifier.NewRandomReadWorker(workerCfg, verifier.NewValidatorStatus(*compacted, *validateLatestValues, *topic, nPartitions))
 			randomWorkers = append(randomWorkers, &worker)
 			workers = append(workers, &worker)
 		}
@@ -311,7 +313,7 @@ func main() {
 		grw := verifier.NewGroupReadWorker(
 			verifier.NewGroupReadConfig(
 				makeWorkerConfig(), *cgName, nPartitions, *cgReaders,
-				*seqConsumeCount, (*consumeTputMb)*1024*1024), verifier.NewValidatorStatus(*compacted))
+				*seqConsumeCount, (*consumeTputMb)*1024*1024), verifier.NewValidatorStatus(*compacted, *validateLatestValues, *topic, nPartitions))
 		workers = append(workers, &grw)
 
 		for loopState.Next() {

--- a/cmd/kgo-verifier/main.go
+++ b/cmd/kgo-verifier/main.go
@@ -72,6 +72,7 @@ var (
 
 	tolerateDataLoss      = flag.Bool("tolerate-data-loss", false, "If true, tolerate data-loss events")
 	tolerateFailedProduce = flag.Bool("tolerate-failed-produce", false, "If true, tolerate and retry failed produce")
+	tombstoneProbability  = flag.Float64("tombstone-probability", 0.0, "The probability (between 0.0 and 1.0) that a record produced is a tombstone record.")
 )
 
 func makeWorkerConfig() worker.WorkerConfig {
@@ -245,7 +246,7 @@ func main() {
 
 	if *pCount > 0 {
 		log.Info("Starting producer...")
-		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, *fakeTimestampStepMs, (*produceRateLimitBps), *keySetCardinality, *msgsPerProducerId)
+		pwc := verifier.NewProducerConfig(makeWorkerConfig(), "producer", nPartitions, *mSize, *pCount, *fakeTimestampMs, *fakeTimestampStepMs, (*produceRateLimitBps), *keySetCardinality, *msgsPerProducerId, *tombstoneProbability)
 		pw := verifier.NewProducerWorker(pwc)
 
 		if *useTransactions {

--- a/pkg/worker/repeater/repeater_worker.go
+++ b/pkg/worker/repeater/repeater_worker.go
@@ -52,13 +52,13 @@ type RepeaterConfig struct {
 	RateLimitBps   int
 }
 
-func NewRepeaterConfig(cfg worker.WorkerConfig, topics []string, group string, keys uint64, payloadSize uint64, dataInFlight uint64, rateLimitBps int) RepeaterConfig {
+func NewRepeaterConfig(cfg worker.WorkerConfig, topics []string, group string, keys uint64, payloadSize uint64, dataInFlight uint64, rateLimitBps int, tombstoneProbability float64) RepeaterConfig {
 	return RepeaterConfig{
 		workerCfg:      cfg,
 		Topics:         topics,
 		Group:          group,
 		KeySpace:       worker.KeySpace{UniqueCount: keys},
-		ValueGenerator: worker.ValueGenerator{PayloadSize: payloadSize, Compressible: cfg.CompressiblePayload},
+		ValueGenerator: worker.ValueGenerator{PayloadSize: payloadSize, Compressible: cfg.CompressiblePayload, TombstoneProbability: tombstoneProbability},
 		DataInFlight:   dataInFlight,
 		RateLimitBps:   rateLimitBps,
 	}

--- a/pkg/worker/verifier/group_read_worker.go
+++ b/pkg/worker/verifier/group_read_worker.go
@@ -49,10 +49,10 @@ type GroupReadWorker struct {
 	Status GroupWorkerStatus
 }
 
-func NewGroupReadWorker(cfg GroupReadConfig) GroupReadWorker {
+func NewGroupReadWorker(cfg GroupReadConfig, validatorStatus ValidatorStatus) GroupReadWorker {
 	return GroupReadWorker{
 		config: cfg,
-		Status: GroupWorkerStatus{Topic: cfg.workerCfg.Topic},
+		Status: GroupWorkerStatus{Topic: cfg.workerCfg.Topic, Validator: validatorStatus},
 	}
 }
 

--- a/pkg/worker/verifier/latest_value_map.go
+++ b/pkg/worker/verifier/latest_value_map.go
@@ -1,0 +1,92 @@
+package verifier
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/redpanda-data/kgo-verifier/pkg/util"
+	log "github.com/sirupsen/logrus"
+)
+
+type LatestValueMap struct {
+	topic               string
+	LatestKvByPartition []map[string]string
+}
+
+func (lvm *LatestValueMap) Get(partition int32, key string) (value string, exists bool) {
+	if partition < 0 || partition >= int32(len(lvm.LatestKvByPartition)) {
+		log.Panicf("Partition %d out of bounds for latestValueMap of size %d", partition, len(lvm.LatestKvByPartition))
+	}
+	value, exists = lvm.LatestKvByPartition[partition][key]
+	return
+}
+
+func (lvm *LatestValueMap) Insert(partition int32, key string, value string) {
+	lvm.LatestKvByPartition[partition][key] = value
+}
+
+func latestValueMapFile(topic string) string {
+	return fmt.Sprintf("latest_value_%s.json", topic)
+}
+
+func (lvm *LatestValueMap) Store() error {
+	log.Infof("LatestValueMap::Storing %s", latestValueMapFile(lvm.topic))
+
+	data, err := json.Marshal(lvm)
+	if err != nil {
+		return err
+	}
+
+	tmp_file, err := ioutil.TempFile("./", "latest_value_*.tmp")
+	if err != nil {
+		return err
+	}
+
+	_, err = tmp_file.Write(data)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(tmp_file.Name(), latestValueMapFile(lvm.topic))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func LoadLatestValues(topic string, nPartitions int32) LatestValueMap {
+	data, err := ioutil.ReadFile(latestValueMapFile(topic))
+	if err != nil {
+		util.Die("Can't read topic latest value map: %v", err)
+	}
+
+	var lvm LatestValueMap
+	if len(data) > 0 {
+		err = json.Unmarshal(data, &lvm)
+		util.Chk(err, "Bad JSON %v", err)
+	}
+
+	if int32(len(lvm.LatestKvByPartition)) > nPartitions {
+		util.Die("More partitions in latest_value_map file than in topic!")
+	} else if len(lvm.LatestKvByPartition) < int(nPartitions) {
+		// Creating new partitions is allowed
+		blanks := make([]map[string]string, nPartitions-int32(len(lvm.LatestKvByPartition)))
+		lvm.LatestKvByPartition = append(lvm.LatestKvByPartition, blanks...)
+	}
+	log.Infof("Successfully read latest value map")
+	return lvm
+}
+
+func NewLatestValueMap(topic string, nPartitions int32) LatestValueMap {
+	maps := make([]map[string]string, nPartitions)
+	for i := range maps {
+		maps[i] = make(map[string]string)
+	}
+	return LatestValueMap{
+		topic:               topic,
+		LatestKvByPartition: maps,
+	}
+}

--- a/pkg/worker/verifier/offset_ranges.go
+++ b/pkg/worker/verifier/offset_ranges.go
@@ -31,6 +31,14 @@ func LoadTopicOffsetRanges(topic string, nPartitions int32) TopicOffsetRanges {
 			tors.PartitionRanges = append(tors.PartitionRanges, blanks...)
 		}
 
+		if int32(len(tors.LastConsumableOffsets)) > nPartitions {
+			util.Die("More partitions in valid_offsets file than in topic!")
+		} else if len(tors.LastConsumableOffsets) < int(nPartitions) {
+			// Creating new partitions is allowed
+			blanks := make([]int64, nPartitions-int32(len(tors.LastConsumableOffsets)))
+			tors.LastConsumableOffsets = append(tors.LastConsumableOffsets, blanks...)
+		}
+
 		return tors
 	}
 }
@@ -105,6 +113,15 @@ func (ors *OffsetRanges) Contains(o int64) bool {
 type TopicOffsetRanges struct {
 	topic           string
 	PartitionRanges []OffsetRanges
+
+	// In the case that the topic being consumed from had tombstones produced,
+	// the high watermark may be given by a tombstone record that has been removed.
+	// In trying to consume until this point, readers will become stuck polling for
+	// new records.
+	AdjustConsumableOffsets bool
+	// Persist the last consumable offset here to adjust the offset we attempt to read
+	// up to in the read workers.
+	LastConsumableOffsets []int64
 }
 
 func (tors *TopicOffsetRanges) Insert(p int32, o int64) {
@@ -113,6 +130,10 @@ func (tors *TopicOffsetRanges) Insert(p int32, o int64) {
 
 func (tors *TopicOffsetRanges) Contains(p int32, o int64) bool {
 	return tors.PartitionRanges[p].Contains(o)
+}
+
+func (tors *TopicOffsetRanges) SetLastConsumableOffset(p int32, o int64) {
+	tors.LastConsumableOffsets[p] = o
 }
 
 func topicOffsetRangeFile(topic string) string {
@@ -153,8 +174,12 @@ func NewTopicOffsetRanges(topic string, nPartitions int32) TopicOffsetRanges {
 	for _, or := range prs {
 		or.Ranges = make([]OffsetRange, 0)
 	}
+	lcos := make([]int64, nPartitions)
+
 	return TopicOffsetRanges{
-		topic:           topic,
-		PartitionRanges: prs,
+		topic:                   topic,
+		PartitionRanges:         prs,
+		AdjustConsumableOffsets: false,
+		LastConsumableOffsets:   lcos,
 	}
 }

--- a/pkg/worker/verifier/producer_worker.go
+++ b/pkg/worker/verifier/producer_worker.go
@@ -110,6 +110,9 @@ func (pw *ProducerWorker) newRecord(producerId int, sequence int64) *kgo.Record 
 	}
 
 	payload := pw.config.valueGenerator.Generate()
+	if payload == nil {
+		pw.Status.TombstonesProduced += 1
+	}
 	var r *kgo.Record
 
 	if pw.config.keySetCardinality < 0 {
@@ -153,6 +156,9 @@ type ProducerWorkerStatus struct {
 
 	// How many times produce request failed?
 	Fails int64 `json:"fails"`
+
+	// How many tombstone records were produced?
+	TombstonesProduced int64 `json:"tombstones_produced"`
 
 	// How many failures occured while trying to begin, abort,
 	// or commit a transaction.

--- a/pkg/worker/verifier/random_read_worker.go
+++ b/pkg/worker/verifier/random_read_worker.go
@@ -42,10 +42,10 @@ func NewRandomReadConfig(wc worker.WorkerConfig, name string, nPartitions int32,
 	}
 }
 
-func NewRandomReadWorker(cfg RandomReadConfig) RandomReadWorker {
+func NewRandomReadWorker(cfg RandomReadConfig, validatorStatus ValidatorStatus) RandomReadWorker {
 	return RandomReadWorker{
 		config: cfg,
-		Status: RandomWorkerStatus{Topic: cfg.workerCfg.Topic},
+		Status: RandomWorkerStatus{Topic: cfg.workerCfg.Topic, Validator: validatorStatus},
 	}
 }
 

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -107,6 +107,15 @@ func (srw *SeqReadWorker) sequentialReadInner(ctx context.Context, startAt []int
 		latestValuesProduced = LoadLatestValues(srw.config.workerCfg.Topic, srw.config.nPartitions)
 	}
 
+	if validRanges.AdjustConsumableOffsets {
+		for i, o := range upTo {
+			if validRanges.LastConsumableOffsets[i] < o {
+				upTo[i] = validRanges.LastConsumableOffsets[i]
+			}
+			log.Debugf("Adjusted offset of upTo from %d to %d", o, upTo[i])
+		}
+	}
+
 	opts := srw.config.workerCfg.MakeKgoOpts()
 	opts = append(opts, []kgo.Opt{
 		kgo.ConsumePartitions(offsets),

--- a/pkg/worker/verifier/seq_read_worker.go
+++ b/pkg/worker/verifier/seq_read_worker.go
@@ -43,10 +43,10 @@ type SeqReadWorker struct {
 	Status SeqWorkerStatus
 }
 
-func NewSeqReadWorker(cfg SeqReadConfig) SeqReadWorker {
+func NewSeqReadWorker(cfg SeqReadConfig, validatorStatus ValidatorStatus) SeqReadWorker {
 	return SeqReadWorker{
 		config: cfg,
-		Status: SeqWorkerStatus{Topic: cfg.workerCfg.Topic},
+		Status: SeqWorkerStatus{Topic: cfg.workerCfg.Topic, Validator: validatorStatus},
 	}
 }
 

--- a/pkg/worker/verifier/validator_status_test.go
+++ b/pkg/worker/verifier/validator_status_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestValidatorStatus_ValidateRecordHappyPath(t *testing.T) {
-	validator := verifier.NewValidatorStatus(false)
+	validator := verifier.NewValidatorStatus(false, false, "topic", 1)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 	validRanges.Insert(0, 41)
 	validRanges.Insert(0, 42)
@@ -19,18 +19,18 @@ func TestValidatorStatus_ValidateRecordHappyPath(t *testing.T) {
 		Offset:      41,
 		LeaderEpoch: 0,
 		Headers:     []kgo.RecordHeader{{Key: "key", Value: []byte("000000.000000000000000041")}},
-	}, &validRanges)
+	}, &validRanges, nil)
 
 	validator.ValidateRecord(&kgo.Record{
 		Offset:      42,
 		LeaderEpoch: 0,
 		Headers:     []kgo.RecordHeader{{Key: "key", Value: []byte("000000.000000000000000042")}},
-	}, &validRanges)
+	}, &validRanges, nil)
 
 	validator.ValidateRecord(&kgo.Record{
 		Offset:      43,
 		LeaderEpoch: 1,
-	}, &validRanges)
+	}, &validRanges, nil)
 
 	assert.Equal(t, int64(2), validator.ValidReads)
 	assert.Equal(t, int64(0), validator.InvalidReads)
@@ -42,7 +42,7 @@ func TestValidatorStatus_ValidateRecordHappyPath(t *testing.T) {
 }
 
 func TestValidatorStatus_ValidateRecordInvalidRead(t *testing.T) {
-	validator := verifier.NewValidatorStatus(false)
+	validator := verifier.NewValidatorStatus(false, false, "topic", 1)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 	validRanges.Insert(0, 41)
 
@@ -58,18 +58,18 @@ func TestValidatorStatus_ValidateRecordInvalidRead(t *testing.T) {
 			Offset:      41,
 			LeaderEpoch: 0,
 			Headers:     []kgo.RecordHeader{{Key: "key", Value: []byte("000000.000000000000000040")}},
-		}, &validRanges)
+		}, &validRanges, nil)
 	}()
 }
 
 func TestValidatorStatus_ValidateRecordNonMonotonicOffset(t *testing.T) {
-	validator := verifier.NewValidatorStatus(false)
+	validator := verifier.NewValidatorStatus(false, false, "topic", 1)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 
 	validator.ValidateRecord(&kgo.Record{
 		Offset:      41,
 		LeaderEpoch: 0,
-	}, &validRanges)
+	}, &validRanges, nil)
 
 	// Same offset read again.
 	func() {
@@ -82,7 +82,7 @@ func TestValidatorStatus_ValidateRecordNonMonotonicOffset(t *testing.T) {
 		validator.ValidateRecord(&kgo.Record{
 			Offset:      41,
 			LeaderEpoch: 0,
-		}, &validRanges)
+		}, &validRanges, nil)
 	}()
 
 	// Lower offset read after a higher offset.
@@ -96,18 +96,18 @@ func TestValidatorStatus_ValidateRecordNonMonotonicOffset(t *testing.T) {
 		validator.ValidateRecord(&kgo.Record{
 			Offset:      40,
 			LeaderEpoch: 0,
-		}, &validRanges)
+		}, &validRanges, nil)
 	}()
 }
 
 func TestValidatorStatus_ValidateRecordNonMonotonicLeaderEpoch(t *testing.T) {
-	validator := verifier.NewValidatorStatus(false)
+	validator := verifier.NewValidatorStatus(false, false, "topic", 1)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 
 	validator.ValidateRecord(&kgo.Record{
 		Offset:      41,
 		LeaderEpoch: 1,
-	}, &validRanges)
+	}, &validRanges, nil)
 
 	func() {
 		defer func() {
@@ -119,7 +119,7 @@ func TestValidatorStatus_ValidateRecordNonMonotonicLeaderEpoch(t *testing.T) {
 		validator.ValidateRecord(&kgo.Record{
 			Offset:      42,
 			LeaderEpoch: 0,
-		}, &validRanges)
+		}, &validRanges, nil)
 	}()
 
 }

--- a/pkg/worker/verifier/validator_status_test.go
+++ b/pkg/worker/verifier/validator_status_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestValidatorStatus_ValidateRecordHappyPath(t *testing.T) {
-	validator := verifier.NewValidatorStatus()
+	validator := verifier.NewValidatorStatus(false)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 	validRanges.Insert(0, 41)
 	validRanges.Insert(0, 42)
@@ -42,7 +42,7 @@ func TestValidatorStatus_ValidateRecordHappyPath(t *testing.T) {
 }
 
 func TestValidatorStatus_ValidateRecordInvalidRead(t *testing.T) {
-	validator := verifier.NewValidatorStatus()
+	validator := verifier.NewValidatorStatus(false)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 	validRanges.Insert(0, 41)
 
@@ -63,7 +63,7 @@ func TestValidatorStatus_ValidateRecordInvalidRead(t *testing.T) {
 }
 
 func TestValidatorStatus_ValidateRecordNonMonotonicOffset(t *testing.T) {
-	validator := verifier.NewValidatorStatus()
+	validator := verifier.NewValidatorStatus(false)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 
 	validator.ValidateRecord(&kgo.Record{
@@ -100,9 +100,8 @@ func TestValidatorStatus_ValidateRecordNonMonotonicOffset(t *testing.T) {
 	}()
 }
 
-
 func TestValidatorStatus_ValidateRecordNonMonotonicLeaderEpoch(t *testing.T) {
-	validator := verifier.NewValidatorStatus()
+	validator := verifier.NewValidatorStatus(false)
 	validRanges := verifier.NewTopicOffsetRanges("topic", 1)
 
 	validator.ValidateRecord(&kgo.Record{

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -100,13 +100,18 @@ type KeySpace struct {
 }
 
 type ValueGenerator struct {
-	PayloadSize  uint64
-	Compressible bool
+	PayloadSize          uint64
+	Compressible         bool
+	TombstoneProbability float64
 }
 
 var compressible_payload []byte
 
 func (vg *ValueGenerator) Generate() []byte {
+	isTombstone := rand.Float64() < vg.TombstoneProbability
+	if isTombstone {
+		return nil
+	}
 	if vg.Compressible {
 		// Zeros, which is about as compressible as an array can be.
 		if len(compressible_payload) == 0 {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -165,6 +165,7 @@ type WorkerConfig struct {
 	TolerateDataLoss      bool
 	TolerateFailedProduce bool
 	Continuous            bool
+	ValidateLatestValues  bool
 }
 
 func CompressionCodecFromString(s string) (kgo.CompressionCodec, error) {


### PR DESCRIPTION
Adds new flags and validation enhancements to `kgo-verifier`:

`--tombstone-probability`, which allows for random production of tombstone records per the input parameter.

`--compacted`, which indicates that the topic to be verified is compacted. A warning about gaps in consumed offsets will not be shown if this is `true`

`--validateLatestValues`, which if true, performs verification of the consumed keys against the latest values produced by a worker. The log should be fully compacted before the consumer is started if this flag is passed as `true`.