### PR TITLE
`verifier`: fix `lastConsumableOffsets`

### DIFF
--- a/pkg/worker/verifier/offset_ranges.go
+++ b/pkg/worker/verifier/offset_ranges.go
@@ -132,6 +132,10 @@ func (tors *TopicOffsetRanges) Contains(p int32, o int64) bool {
 	return tors.PartitionRanges[p].Contains(o)
 }
 
+func (tors *TopicOffsetRanges) GetLastConsumableOffset(p int32) int64 {
+	return tors.LastConsumableOffsets[p]
+}
+
 func (tors *TopicOffsetRanges) SetLastConsumableOffset(p int32, o int64) {
 	tors.LastConsumableOffsets[p] = o
 }

--- a/pkg/worker/verifier/validator_status.go
+++ b/pkg/worker/verifier/validator_status.go
@@ -113,8 +113,8 @@ func (cs *ValidatorStatus) ValidateRecord(r *kgo.Record, validRanges *TopicOffse
 	}
 
 	if cs.expectFullyCompacted {
-		latestValue, exists := latestValuesProduced.Get(r.Partition, string(r.Key))
-		if !exists || latestValue != string(r.Value) {
+		latestValue, exists := latestValuesProduced.GetValue(r.Partition, string(r.Key))
+		if !exists || string(latestValue) != string(r.Value) {
 			log.Panicf("Consumed value for key %s does not match the latest produced value in a compacted topic- did compaction for partition %s/%d occur betwen producing and consuming?", r.Key, r.Topic, r.Partition)
 		}
 	}


### PR DESCRIPTION
This didn't account for tombstones being produced for the same key later in the log.

Fix the logic by adding a new `latestKoByPartition` map which tracks the last offset for a given key. By using it in combination with `latestKvByPartition`, we can conclude which non-tombstone record/key has the highest offset for a given partition.