### PR TITLE
Repeater should leave CG on graceful shutdown

### DIFF
--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -172,6 +172,12 @@ func main() {
 			log.Infof("Waiting for worker %d complete", i)
 			log.Infof("Verifier %d result: %s", i, result.String())
 		}
+
+		for i, v := range verifiers {
+			log.Infof("Shutting down worker %d...", i)
+			(*v).Shutdown()
+			log.Infof("Worker %d shutdown complete", i)
+		}
 	}
 
 	// Even if we're not in remote mode, start the HTTP listener so

--- a/cmd/kgo-repeater/main.go
+++ b/cmd/kgo-repeater/main.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"runtime/pprof"
 	"strings"
+	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -127,7 +128,7 @@ func main() {
 	}
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	var verifiers []*repeater.Worker
 


### PR DESCRIPTION
Listen for SIGTERM and call all Shutdown() in the verifiers.

See commits and CORE-8470 for additional context.